### PR TITLE
fix: update code block syntax for log output in MCP server article

### DIFF
--- a/src/md-pages/976f8b32-937c-4cb8-b6f5-6d5e62228750/article976f8b32-937c-4cb8-b6f5-6d5e62228750.md
+++ b/src/md-pages/976f8b32-937c-4cb8-b6f5-6d5e62228750/article976f8b32-937c-4cb8-b6f5-6d5e62228750.md
@@ -181,7 +181,7 @@ MCPサーバを使ってもらうように設定ファイル (`~/Library/Applica
 うまく起動しない。
 `mcp.log`と `mcp-server-mcp-server-sample.log`に以下のように出力されていた。
 
-```
+```text
 2025-04-11T12:09:05.526Z [info] [mcp-server-sample] Initializing server...
 2025-04-11T12:09:05.541Z [error] [mcp-server-sample] spawn node ENOENT
 2025-04-11T12:09:05.541Z [error] [mcp-server-sample] spawn node ENOENT
@@ -191,7 +191,7 @@ MCPサーバを使ってもらうように設定ファイル (`~/Library/Applica
 2025-04-11T12:09:05.543Z [error] [mcp-server-sample] Server disconnected. For troubleshooting guidance, please visit our [debugging documentation](https://modelcontextprotocol.io/docs/tools/debugging)
 ```
 
-```
+```text
 2025-04-11T12:09:05.526Z [mcp-server-sample] [info] Initializing server...
 2025-04-11T12:09:05.540Z [mcp-server-sample] [error] spawn node ENOENT {"context":"connection","stack":"Error: spawn node ENOENT\n    at ChildProcess._handle.onexit (node:internal/child_process:285:19)\n    at onErrorNT (node:internal/child_process:483:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"}
 2025-04-11T12:09:05.541Z [mcp-server-sample] [error] spawn node ENOENT {"stack":"Error: spawn node ENOENT\n    at ChildProcess._handle.onexit (node:internal/child_process:285:19)\n    at onErrorNT (node:internal/child_process:483:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)"}


### PR DESCRIPTION
## What is the current behavior?

## What is the new behavior?
