### PR TITLE
feat: PlaywrightベースのVisual Regressionテスト基盤を導入

### DIFF
--- a/.github/scripts/parse-visual-regression-results.js
+++ b/.github/scripts/parse-visual-regression-results.js
@@ -1,0 +1,233 @@
+const fs = require('fs');
+const path = require('path');
+
+const COMMENT_IDENTIFIER = '<!-- visual-regression-report -->';
+const DEFAULT_REPORT_PATH = 'test-results/playwright-report.json';
+const DEFAULT_OUTPUT_PATH = 'test-results/visual-regression-comment.md';
+const DIFF_MESSAGE_PATTERN =
+  /diffRatio\s*\(([-+]?\d*\.?\d+(?:e[-+]?\d+)?)\)\s*exceeded threshold\s*\(([-+]?\d*\.?\d+(?:e[-+]?\d+)?)\)\s*for\s*(T\d+)/i;
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function parseSpecTitle(title) {
+  if (typeof title !== 'string') {
+    return { id: null, description: '' };
+  }
+  const match = title.match(/^\s*(T\d+)\s*:\s*(.+)\s*$/);
+  if (!match) {
+    return { id: null, description: title.trim() };
+  }
+  return {
+    id: match[1],
+    description: match[2].trim(),
+  };
+}
+
+function getErrorMessages(result) {
+  const errors = toArray(result?.errors);
+  const messages = [];
+  for (const error of errors) {
+    if (error && typeof error.message === 'string') {
+      messages.push(error.message);
+    }
+  }
+  if (result?.error && typeof result.error.message === 'string') {
+    messages.push(result.error.message);
+  }
+  return messages;
+}
+
+function parseDiffMetrics(messages) {
+  for (const message of messages) {
+    const match = String(message).match(DIFF_MESSAGE_PATTERN);
+    if (match) {
+      return {
+        id: match[3],
+        diffRatio: Number.parseFloat(match[1]),
+        threshold: Number.parseFloat(match[2]),
+      };
+    }
+  }
+  return {
+    id: null,
+    diffRatio: null,
+    threshold: null,
+  };
+}
+
+function isFailedStatus(status) {
+  return status === 'failed' || status === 'timedOut' || status === 'interrupted';
+}
+
+function walkSuites(suites, visitor) {
+  for (const suite of toArray(suites)) {
+    for (const spec of toArray(suite.specs)) {
+      visitor(spec);
+    }
+    walkSuites(suite.suites, visitor);
+  }
+}
+
+function extractFailuresFromReport(report) {
+  const failures = [];
+  walkSuites(report?.suites, spec => {
+    const parsedTitle = parseSpecTitle(spec?.title);
+    for (const testCase of toArray(spec?.tests)) {
+      const results = toArray(testCase?.results);
+      const finalResult = results.at(-1);
+      const failedByStatus = isFailedStatus(testCase?.status);
+      const failedByFinalResult = isFailedStatus(finalResult?.status);
+      if (!failedByStatus && !failedByFinalResult) {
+        continue;
+      }
+
+      const failedResults = results.filter(result => isFailedStatus(result?.status));
+      const failureSources = failedResults.length > 0 ? failedResults : [finalResult];
+      const messages = failureSources.flatMap(getErrorMessages);
+      const metrics = parseDiffMetrics(messages);
+      const id = metrics.id || parsedTitle.id || 'UNKNOWN';
+      const description = parsedTitle.description || String(spec?.title || '').trim();
+      const project = typeof testCase?.projectName === 'string' ? testCase.projectName : '';
+
+      failures.push({
+        id,
+        description,
+        project,
+        diffRatio: Number.isFinite(metrics.diffRatio) ? metrics.diffRatio : null,
+        threshold: Number.isFinite(metrics.threshold) ? metrics.threshold : null,
+      });
+    }
+  });
+
+  return failures;
+}
+
+function formatPercent(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'N/A';
+  }
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function normalizeProject(project) {
+  if (!project) {
+    return '-';
+  }
+  return String(project).toUpperCase();
+}
+
+function buildVisualRegressionComment(input) {
+  const failures = toArray(input?.failures);
+  const reportUrl = String(input?.reportUrl || '').trim();
+  const lines = [
+    COMMENT_IDENTIFIER,
+    '## ⚠️ Visual Regression Test Failed',
+    '',
+  ];
+
+  if (failures.length === 0) {
+    lines.push(
+      '失敗は検出されましたが、失敗テストの詳細を抽出できませんでした。',
+      '',
+    );
+  } else {
+    const failedIds = [...new Set(failures.map(failure => failure.id))];
+    lines.push(`**失敗:** ${failedIds.join(', ')}`, '');
+    lines.push('| Test ID | Description | Project | Diff Ratio | Threshold |');
+    lines.push('|---------|-------------|---------|------------|-----------|');
+
+    for (const failure of failures) {
+      const safeDescription = String(failure.description || '').replace(/\|/g, '\\|');
+      lines.push(
+        `| ${failure.id} | ${safeDescription} | ${normalizeProject(
+          failure.project,
+        )} | ${formatPercent(failure.diffRatio)} | ${formatPercent(failure.threshold)} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (reportUrl) {
+    lines.push(`**Detailed Report:** [View HTML Report](${reportUrl})`, '');
+  }
+
+  lines.push(
+    '---',
+    '<details>',
+    '<summary>How to fix</summary>',
+    '',
+    '1. HTMLレポートで差分を確認',
+    '2. 意図した変更ならこのPRをマージ',
+    '3. 意図しない変更ならスタイルを修正',
+    '',
+    '</details>',
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+function parseCliArgs(argv) {
+  const args = {
+    reportPath: DEFAULT_REPORT_PATH,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    reportUrl: '',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--report-path' && argv[i + 1]) {
+      args.reportPath = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (token === '--output-path' && argv[i + 1]) {
+      args.outputPath = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (token === '--report-url' && argv[i + 1]) {
+      args.reportUrl = argv[i + 1];
+      i += 1;
+    }
+  }
+
+  return args;
+}
+
+function runCli(argv) {
+  const args = parseCliArgs(argv);
+  let report = {};
+
+  if (fs.existsSync(args.reportPath)) {
+    const raw = fs.readFileSync(args.reportPath, 'utf-8');
+    report = JSON.parse(raw);
+  }
+
+  const failures = extractFailuresFromReport(report);
+  const body = buildVisualRegressionComment({
+    failures,
+    reportUrl: args.reportUrl,
+  });
+
+  fs.mkdirSync(path.dirname(args.outputPath), { recursive: true });
+  fs.writeFileSync(args.outputPath, body);
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `failure_count=${failures.length}\n`);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `comment_path=${args.outputPath}\n`);
+  }
+}
+
+if (require.main === module) {
+  runCli(process.argv.slice(2));
+}
+
+module.exports = {
+  COMMENT_IDENTIFIER,
+  extractFailuresFromReport,
+  buildVisualRegressionComment,
+  runCli,
+};

--- a/.github/workflows/visual-regression-cleanup.yml
+++ b/.github/workflows/visual-regression-cleanup.yml
@@ -1,0 +1,51 @@
+name: Visual Regression Cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Remove closed PR report directory from gh-pages
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+
+          if ! git fetch origin gh-pages:gh-pages; then
+            echo "gh-pages branch does not exist. Skip cleanup."
+            exit 0
+          fi
+
+          git checkout gh-pages
+
+          target_dir="pr-${PR_NUMBER}"
+          if [ ! -d "${target_dir}" ]; then
+            echo "${target_dir} does not exist. Skip cleanup."
+            exit 0
+          fi
+
+          rm -rf "${target_dir}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "No cleanup changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore: remove visual regression report for PR #${PR_NUMBER}"
+          git push origin gh-pages

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,107 @@
+name: Visual Regression
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  visual-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      deployments: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: yarn playwright install --with-deps chromium
+
+      - name: Resolve Vercel preview URL from Deployment API
+        id: resolve-preview
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.payload.pull_request?.head?.sha || context.sha;
+            const timeoutMs = 5 * 60 * 1000;
+            const intervalMs = 10 * 1000;
+            const startedAt = Date.now();
+            let previewUrl = '';
+
+            while (Date.now() - startedAt < timeoutMs) {
+              const deployments = await github.paginate(github.rest.repos.listDeployments, {
+                owner,
+                repo,
+                sha,
+                per_page: 100,
+              });
+
+              for (const deployment of deployments) {
+                const statuses = await github.paginate(github.rest.repos.listDeploymentStatuses, {
+                  owner,
+                  repo,
+                  deployment_id: deployment.id,
+                  per_page: 100,
+                });
+
+                const successStatus = statuses.find(status => {
+                  if (status.state !== 'success') {
+                    return false;
+                  }
+                  const url = status.environment_url || status.target_url || '';
+                  return url.includes('vercel.app');
+                });
+
+                if (successStatus) {
+                  previewUrl = (successStatus.environment_url || successStatus.target_url || '').replace(/\/$/, '');
+                  break;
+                }
+              }
+
+              if (previewUrl) {
+                break;
+              }
+
+              core.info('Vercel preview deployment is not ready yet. Waiting 10 seconds...');
+              await new Promise(resolve => setTimeout(resolve, intervalMs));
+            }
+
+            if (!previewUrl) {
+              core.setFailed('Could not resolve Vercel preview URL from GitHub Deployment API within 5 minutes.');
+              return;
+            }
+
+            core.info(`Resolved preview URL: ${previewUrl}`);
+            core.setOutput('preview_url', previewUrl);
+
+      - name: Run visual regression tests
+        env:
+          VERCEL_PREVIEW_URL: ${{ steps.resolve-preview.outputs.preview_url }}
+        run: yarn test:visual tests/visual-regression
+
+      - name: Upload visual diff artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-artifacts
+          path: |
+            test-results
+            playwright-report
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: write
       deployments: read
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -91,12 +92,101 @@ jobs:
             core.setOutput('preview_url', previewUrl);
 
       - name: Run visual regression tests
+        id: test
+        continue-on-error: true
         env:
           VERCEL_PREVIEW_URL: ${{ steps.resolve-preview.outputs.preview_url }}
         run: yarn test:visual tests/visual-regression
 
+      - name: Set test result
+        if: always()
+        id: test-result
+        run: |
+          if [ "${{ steps.test.outcome }}" = "success" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy visual report to GitHub Pages
+        if: always()
+        continue-on-error: true
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./playwright-report
+          destination_dir: pr-${{ github.event.pull_request.number }}
+          keep_files: true
+          enable_jekyll: false
+
+      - name: Build PR comment body
+        if: always() && steps.test-result.outputs.status == 'failure'
+        id: build-comment
+        continue-on-error: true
+        env:
+          REPORT_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+        run: |
+          node .github/scripts/parse-visual-regression-results.js \
+            --report-path test-results/playwright-report.json \
+            --output-path test-results/visual-regression-comment.md \
+            --report-url "$REPORT_URL"
+
+      - name: Upsert visual regression comment
+        if: always() && steps.test-result.outputs.status == 'failure'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          COMMENT_PATH: ${{ steps.build-comment.outputs.comment_path }}
+          REPORT_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+        with:
+          script: |
+            const fs = require('fs');
+            const identifier = '<!-- visual-regression-report -->';
+            const commentPath = process.env.COMMENT_PATH || 'test-results/visual-regression-comment.md';
+            const reportUrl = process.env.REPORT_URL || '';
+
+            let body = `${identifier}
+            ## ⚠️ Visual Regression Test Failed
+
+            詳細なテスト結果の抽出に失敗しました。
+
+            **Detailed Report:** ${reportUrl}
+            `;
+
+            if (fs.existsSync(commentPath)) {
+              body = fs.readFileSync(commentPath, 'utf8');
+            }
+
+            const { owner, repo } = context.repo;
+            const issueNumber = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existingComment = comments.find(comment =>
+              typeof comment.body === 'string' && comment.body.includes(identifier)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
+
       - name: Upload visual diff artifacts
-        if: failure()
+        if: always() && steps.test-result.outputs.status == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: visual-regression-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/playwright/.cache
+/tests/visual-regression/__screenshots__
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,32 @@
 # MyBlog
 
 個人用のブログ
+
+## Visual Regression Test
+
+### 実行方法
+
+```bash
+yarn test:visual tests/visual-regression
+```
+
+`VERCEL_PREVIEW_URL` を指定すると、本番環境とプレビュー環境の差分比較を実行します。
+
+```bash
+VERCEL_PREVIEW_URL=https://example-preview.vercel.app yarn test:visual tests/visual-regression
+```
+
+`VERCEL_PREVIEW_URL` 未指定時は、本番環境同士の比較（差分なし想定）として実行されます。
+
+### 生成物
+
+- `test-results/production/*.png` : 本番環境スクリーンショット
+- `test-results/preview/*.png` : プレビュー環境スクリーンショット
+- `test-results/diff/*.png` : 差分画像
+- `test-results/diff/*.json` : 差分率レポート
+
+### CI
+
+- GitHub Actions: `.github/workflows/visual-regression.yml`
+- GitHub Deployment API から Vercel プレビューURLを取得して比較します
+- 失敗時は `test-results` / `playwright-report` がアーティファクトに保存されます。

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@types/mdx": "^2.0.13",
     "@types/node": "^17.0.35",
+    "@types/pngjs": "^6.0.5",
     "@types/react": "19.0.12",
     "@types/react-dom": "19.0.4",
     "@types/react-helmet": "^6.1.5",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "next",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "next start",
+    "test:visual": "playwright test",
     "create:md": "tsx ./scripts/article-scripts/article-creator.mts",
     "rename:files": "tsx ./scripts/article-scripts/article-creator.mts --rename",
     "generate:rss": "tsx ./scripts/generate-rss/generate-rss.mts",
@@ -42,6 +43,7 @@
     "unified": "^10.1.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/typography": "^0.5.19",
     "@types/mdx": "^2.0.13",
     "@types/node": "^17.0.35",
@@ -49,6 +51,8 @@
     "@types/react-dom": "19.0.4",
     "@types/react-helmet": "^6.1.5",
     "feed": "^4.2.2",
+    "pixelmatch": "^7.1.0",
+    "pngjs": "^7.0.0",
     "prettier": "2.6.2",
     "puppeteer": "^14.1.1",
     "raw-loader": "^4.0.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/visual-regression',
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60 * 1000,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    browserName: 'chromium',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'sp',
+      use: {
+        ...devices['iPhone 14'],
+        viewport: { width: 375, height: 667 },
+      },
+    },
+    {
+      name: 'pc',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,13 @@ export default defineConfig({
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
   timeout: 60 * 1000,
-  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        ['json', { outputFile: 'test-results/playwright-report.json' }],
+        ['html', { open: 'never' }],
+      ]
+    : 'list',
   use: {
     browserName: 'chromium',
     trace: 'on-first-retry',

--- a/tests/visual-regression/compare.spec.ts
+++ b/tests/visual-regression/compare.spec.ts
@@ -23,7 +23,8 @@ function createPngFile(
       png.data[idx + 3] = 255;
     }
   }
-  fs.writeFileSync(filePath, PNG.sync.write(png));
+  const encoded = PNG.sync.write(png);
+  fs.writeFileSync(filePath, new Uint8Array(encoded));
 }
 
 test.describe('Screenshot compare', () => {

--- a/tests/visual-regression/compare.spec.ts
+++ b/tests/visual-regression/compare.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { PNG } from 'pngjs';
+import { compareScreenshots } from './compare';
+
+function createPngFile(
+  filePath: string,
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+) {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (width * y + x) << 2;
+      png.data[idx] = r;
+      png.data[idx + 1] = g;
+      png.data[idx + 2] = b;
+      png.data[idx + 3] = 255;
+    }
+  }
+  fs.writeFileSync(filePath, PNG.sync.write(png));
+}
+
+test.describe('Screenshot compare', () => {
+  test('should return 0 diff for identical images', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vrs-identical-'));
+    const productionPath = path.join(tmpDir, 'production.png');
+    const previewPath = path.join(tmpDir, 'preview.png');
+    const diffPath = path.join(tmpDir, 'diff.png');
+    const reportPath = path.join(tmpDir, 'report.json');
+
+    createPngFile(productionPath, 4, 4, 100, 120, 140);
+    createPngFile(previewPath, 4, 4, 100, 120, 140);
+
+    const result = await compareScreenshots({
+      productionPath,
+      previewPath,
+      diffPath,
+      reportPath,
+    });
+
+    expect(result.diffPixels).toBe(0);
+    expect(result.diffRatio).toBe(0);
+    expect(fs.existsSync(diffPath)).toBeTruthy();
+    expect(fs.existsSync(reportPath)).toBeTruthy();
+  });
+
+  test('should detect diff for different images', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vrs-different-'));
+    const productionPath = path.join(tmpDir, 'production.png');
+    const previewPath = path.join(tmpDir, 'preview.png');
+    const diffPath = path.join(tmpDir, 'diff.png');
+
+    createPngFile(productionPath, 4, 4, 0, 0, 0);
+    createPngFile(previewPath, 4, 4, 255, 255, 255);
+
+    const result = await compareScreenshots({
+      productionPath,
+      previewPath,
+      diffPath,
+    });
+
+    expect(result.diffPixels).toBeGreaterThan(0);
+    expect(result.diffRatio).toBeGreaterThan(0);
+  });
+
+  test('should throw when image dimensions are different', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vrs-size-'));
+    const productionPath = path.join(tmpDir, 'production.png');
+    const previewPath = path.join(tmpDir, 'preview.png');
+    const diffPath = path.join(tmpDir, 'diff.png');
+
+    createPngFile(productionPath, 4, 4, 0, 0, 0);
+    createPngFile(previewPath, 8, 8, 0, 0, 0);
+
+    await expect(
+      compareScreenshots({
+        productionPath,
+        previewPath,
+        diffPath,
+      }),
+    ).rejects.toThrow('Screenshot dimensions do not match');
+  });
+});

--- a/tests/visual-regression/compare.ts
+++ b/tests/visual-regression/compare.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+
+export type CompareScreenshotsInput = {
+  productionPath: string;
+  previewPath: string;
+  diffPath: string;
+  reportPath?: string;
+  comparisonThreshold?: number;
+  pixelmatchThreshold?: number;
+};
+
+export type CompareScreenshotsResult = {
+  diffPixels: number;
+  totalPixels: number;
+  diffRatio: number;
+  threshold: number;
+};
+
+function ensureDirectory(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+export async function compareScreenshots(
+  input: CompareScreenshotsInput,
+): Promise<CompareScreenshotsResult> {
+  const productionBuffer = fs.readFileSync(input.productionPath);
+  const previewBuffer = fs.readFileSync(input.previewPath);
+  const production = PNG.sync.read(productionBuffer);
+  const preview = PNG.sync.read(previewBuffer);
+
+  if (
+    production.width !== preview.width ||
+    production.height !== preview.height
+  ) {
+    throw new Error('Screenshot dimensions do not match');
+  }
+
+  const diff = new PNG({ width: production.width, height: production.height });
+  const diffPixels = pixelmatch(
+    production.data,
+    preview.data,
+    diff.data,
+    production.width,
+    production.height,
+    {
+      threshold: input.pixelmatchThreshold ?? 0.1,
+    },
+  );
+  const totalPixels = production.width * production.height;
+  const diffRatio = totalPixels === 0 ? 0 : diffPixels / totalPixels;
+  const threshold = input.comparisonThreshold ?? 0.001;
+
+  ensureDirectory(input.diffPath);
+  fs.writeFileSync(input.diffPath, PNG.sync.write(diff));
+
+  if (input.reportPath) {
+    ensureDirectory(input.reportPath);
+    fs.writeFileSync(
+      input.reportPath,
+      JSON.stringify(
+        {
+          diffPixels,
+          totalPixels,
+          diffRatio,
+          threshold,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  return {
+    diffPixels,
+    totalPixels,
+    diffRatio,
+    threshold,
+  };
+}

--- a/tests/visual-regression/config.spec.ts
+++ b/tests/visual-regression/config.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import {
+  buildPageUrl,
+  getPreviewBaseUrl,
+  PRODUCTION_BASE_URL,
+} from './config';
+
+test.describe('Visual regression config', () => {
+  let originalPreviewUrl: string | undefined;
+
+  test.beforeEach(() => {
+    originalPreviewUrl = process.env.VERCEL_PREVIEW_URL;
+  });
+
+  test.afterEach(() => {
+    if (originalPreviewUrl === undefined) {
+      delete process.env.VERCEL_PREVIEW_URL;
+      return;
+    }
+    process.env.VERCEL_PREVIEW_URL = originalPreviewUrl;
+  });
+
+  test('T20: should use VERCEL_PREVIEW_URL when provided', () => {
+    process.env.VERCEL_PREVIEW_URL = 'https://example-preview.vercel.app/';
+
+    const result = getPreviewBaseUrl();
+
+    expect(result.url).toBe('https://example-preview.vercel.app');
+    expect(result.source).toBe('env');
+  });
+
+  test('T20: should fallback to production URL when preview URL is missing', () => {
+    delete process.env.VERCEL_PREVIEW_URL;
+
+    const result = getPreviewBaseUrl();
+
+    expect(result.url).toBe(PRODUCTION_BASE_URL);
+    expect(result.source).toBe('fallback-production');
+  });
+
+  test('should build root page URL', () => {
+    expect(buildPageUrl('https://example.com', '/')).toBe('https://example.com/');
+  });
+
+  test('should build nested page URL', () => {
+    expect(buildPageUrl('https://example.com/', '/tags')).toBe(
+      'https://example.com/tags',
+    );
+  });
+});

--- a/tests/visual-regression/config.ts
+++ b/tests/visual-regression/config.ts
@@ -1,0 +1,32 @@
+export const PRODUCTION_BASE_URL = 'https://tminasen.dev';
+
+export type PreviewUrlSource = 'env' | 'fallback-production';
+
+export type PreviewBaseUrl = {
+  url: string;
+  source: PreviewUrlSource;
+};
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export function getPreviewBaseUrl(): PreviewBaseUrl {
+  const previewUrl = process.env.VERCEL_PREVIEW_URL?.trim();
+
+  if (previewUrl) {
+    return {
+      url: normalizeBaseUrl(previewUrl),
+      source: 'env',
+    };
+  }
+
+  return {
+    url: PRODUCTION_BASE_URL,
+    source: 'fallback-production',
+  };
+}
+
+export function buildPageUrl(baseUrl: string, pagePath: string): string {
+  return new URL(pagePath, `${normalizeBaseUrl(baseUrl)}/`).toString();
+}

--- a/tests/visual-regression/helpers.spec.ts
+++ b/tests/visual-regression/helpers.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+import { PRODUCTION_BASE_URL, buildPageUrl } from './config';
+import { setColorScheme, waitForPageReady } from './helpers';
+
+test.describe('Visual helper', () => {
+  test('T18: color scheme switch should update root color variables', async ({
+    page,
+  }) => {
+    await page.goto(buildPageUrl(PRODUCTION_BASE_URL, '/404'));
+
+    await setColorScheme(page, 'light');
+    const lightColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-bg-base')
+        .trim(),
+    );
+
+    await setColorScheme(page, 'dark');
+    const darkColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-bg-base')
+        .trim(),
+    );
+
+    await setColorScheme(page, 'light');
+    const revertedLightColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-bg-base')
+        .trim(),
+    );
+
+    expect(lightColor).toBe('#f5f5f5');
+    expect(darkColor).toBe('#1f2937');
+    expect(revertedLightColor).toBe(lightColor);
+  });
+
+  test('T19: waitForPageReady should wait until fonts are loaded', async ({
+    page,
+  }) => {
+    await page.goto(buildPageUrl(PRODUCTION_BASE_URL, '/'));
+    await waitForPageReady(page);
+
+    const fontStatus = await page.evaluate(() => document.fonts.status);
+    expect(fontStatus).toBe('loaded');
+  });
+});

--- a/tests/visual-regression/helpers.ts
+++ b/tests/visual-regression/helpers.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import type { Page } from '@playwright/test';
+
+export type ColorScheme = 'light' | 'dark';
+
+export type TakeScreenshotInput = {
+  url: string;
+  colorScheme: ColorScheme;
+  outputPath: string;
+};
+
+export async function setColorScheme(
+  page: Page,
+  colorScheme: ColorScheme,
+): Promise<void> {
+  await page.emulateMedia({ colorScheme });
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => resolve());
+      }),
+  );
+}
+
+export async function waitForPageReady(page: Page): Promise<void> {
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+}
+
+export async function takeScreenshot(
+  page: Page,
+  input: TakeScreenshotInput,
+): Promise<void> {
+  await setColorScheme(page, input.colorScheme);
+  await page.goto(input.url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await waitForPageReady(page);
+
+  fs.mkdirSync(path.dirname(input.outputPath), { recursive: true });
+  await page.screenshot({
+    path: input.outputPath,
+    fullPage: true,
+    animations: 'disabled',
+  });
+}

--- a/tests/visual-regression/pages.spec.ts
+++ b/tests/visual-regression/pages.spec.ts
@@ -1,0 +1,232 @@
+import { expect, test } from '@playwright/test';
+import path from 'path';
+import { compareScreenshots } from './compare';
+import { buildPageUrl, getPreviewBaseUrl, PRODUCTION_BASE_URL } from './config';
+import { ColorScheme, takeScreenshot } from './helpers';
+
+type VisualRegressionCase = {
+  id:
+    | 'T1'
+    | 'T2'
+    | 'T3'
+    | 'T4'
+    | 'T5'
+    | 'T6'
+    | 'T7'
+    | 'T8'
+    | 'T9'
+    | 'T10'
+    | 'T11'
+    | 'T12'
+    | 'T13'
+    | 'T14'
+    | 'T15'
+    | 'T16';
+  description: string;
+  project: 'sp' | 'pc';
+  colorScheme: ColorScheme;
+  pagePath: string;
+  artifactName: string;
+  maxDiffRatio?: number;
+};
+
+const cases: VisualRegressionCase[] = [
+  {
+    id: 'T1',
+    description: '404 page should match screenshot in SP light mode',
+    project: 'sp',
+    colorScheme: 'light',
+    pagePath: '/404',
+    artifactName: '404-sp-light',
+  },
+  {
+    id: 'T2',
+    description: '404 page should match screenshot in PC light mode',
+    project: 'pc',
+    colorScheme: 'light',
+    pagePath: '/404',
+    artifactName: '404-pc-light',
+  },
+  {
+    id: 'T3',
+    description: '404 page should match screenshot in SP dark mode',
+    project: 'sp',
+    colorScheme: 'dark',
+    pagePath: '/404',
+    artifactName: '404-sp-dark',
+  },
+  {
+    id: 'T4',
+    description: '404 page should match screenshot in PC dark mode',
+    project: 'pc',
+    colorScheme: 'dark',
+    pagePath: '/404',
+    artifactName: '404-pc-dark',
+  },
+  {
+    id: 'T5',
+    description: 'tags page should match screenshot in SP light mode',
+    project: 'sp',
+    colorScheme: 'light',
+    pagePath: '/tags',
+    artifactName: 'tags-sp-light',
+  },
+  {
+    id: 'T6',
+    description: 'tags page should match screenshot in PC light mode',
+    project: 'pc',
+    colorScheme: 'light',
+    pagePath: '/tags',
+    artifactName: 'tags-pc-light',
+  },
+  {
+    id: 'T7',
+    description: 'tags page should match screenshot in SP dark mode',
+    project: 'sp',
+    colorScheme: 'dark',
+    pagePath: '/tags',
+    artifactName: 'tags-sp-dark',
+  },
+  {
+    id: 'T8',
+    description: 'tags page should match screenshot in PC dark mode',
+    project: 'pc',
+    colorScheme: 'dark',
+    pagePath: '/tags',
+    artifactName: 'tags-pc-dark',
+  },
+  {
+    id: 'T9',
+    description: 'top page should match screenshot in SP light mode',
+    project: 'sp',
+    colorScheme: 'light',
+    pagePath: '/',
+    artifactName: 'top-sp-light',
+  },
+  {
+    id: 'T10',
+    description: 'top page should match screenshot in PC light mode',
+    project: 'pc',
+    colorScheme: 'light',
+    pagePath: '/',
+    artifactName: 'top-pc-light',
+  },
+  {
+    id: 'T11',
+    description: 'top page should match screenshot in SP dark mode',
+    project: 'sp',
+    colorScheme: 'dark',
+    pagePath: '/',
+    artifactName: 'top-sp-dark',
+  },
+  {
+    id: 'T12',
+    description: 'top page should match screenshot in PC dark mode',
+    project: 'pc',
+    colorScheme: 'dark',
+    pagePath: '/',
+    artifactName: 'top-pc-dark',
+  },
+  {
+    id: 'T13',
+    description: 'article page should match screenshot in SP light mode',
+    project: 'sp',
+    colorScheme: 'light',
+    pagePath: '/blog/20200520',
+    artifactName: 'article-sp-light',
+  },
+  {
+    id: 'T14',
+    description: 'article page should match screenshot in PC light mode',
+    project: 'pc',
+    colorScheme: 'light',
+    pagePath: '/blog/20200520',
+    artifactName: 'article-pc-light',
+  },
+  {
+    id: 'T15',
+    description: 'article page should match screenshot in SP dark mode',
+    project: 'sp',
+    colorScheme: 'dark',
+    pagePath: '/blog/20200520',
+    artifactName: 'article-sp-dark',
+  },
+  {
+    id: 'T16',
+    description: 'article page should match screenshot in PC dark mode',
+    project: 'pc',
+    colorScheme: 'dark',
+    pagePath: '/blog/20200520',
+    artifactName: 'article-pc-dark',
+  },
+];
+
+const DEFAULT_MAX_DIFF_RATIO = 0.001;
+const previewBaseUrl = getPreviewBaseUrl();
+
+test.describe('Visual regression', () => {
+  for (const visualCase of cases) {
+    test(`${visualCase.id}: ${visualCase.description}`, async ({ page }, testInfo) => {
+      test.skip(
+        testInfo.project.name !== visualCase.project,
+        `${visualCase.id} is ${visualCase.project.toUpperCase()} only`,
+      );
+
+      if (previewBaseUrl.source === 'fallback-production') {
+        testInfo.annotations.push({
+          type: 'warning',
+          description:
+            'VERCEL_PREVIEW_URL is not set. Comparing production against production.',
+        });
+      }
+
+      const productionUrl = buildPageUrl(PRODUCTION_BASE_URL, visualCase.pagePath);
+      const previewUrl = buildPageUrl(previewBaseUrl.url, visualCase.pagePath);
+      const productionPath = path.join(
+        'test-results',
+        'production',
+        `${visualCase.artifactName}.png`,
+      );
+      const previewPath = path.join(
+        'test-results',
+        'preview',
+        `${visualCase.artifactName}.png`,
+      );
+      const diffPath = path.join(
+        'test-results',
+        'diff',
+        `${visualCase.artifactName}.png`,
+      );
+      const reportPath = path.join(
+        'test-results',
+        'diff',
+        `${visualCase.artifactName}.json`,
+      );
+      const threshold = visualCase.maxDiffRatio ?? DEFAULT_MAX_DIFF_RATIO;
+
+      await takeScreenshot(page, {
+        url: productionUrl,
+        colorScheme: visualCase.colorScheme,
+        outputPath: productionPath,
+      });
+      await takeScreenshot(page, {
+        url: previewUrl,
+        colorScheme: visualCase.colorScheme,
+        outputPath: previewPath,
+      });
+
+      const result = await compareScreenshots({
+        productionPath,
+        previewPath,
+        diffPath,
+        reportPath,
+        comparisonThreshold: threshold,
+      });
+
+      expect(
+        result.diffRatio,
+        `diffRatio (${result.diffRatio}) exceeded threshold (${threshold}) for ${visualCase.id}`,
+      ).toBeLessThanOrEqual(threshold);
+    });
+  }
+});

--- a/tests/visual-regression/parse-visual-regression-results.test.ts
+++ b/tests/visual-regression/parse-visual-regression-results.test.ts
@@ -1,0 +1,150 @@
+import { expect, test } from '@playwright/test';
+
+type VisualFailure = {
+  id: string;
+  description: string;
+  project: string;
+  diffRatio: number | null;
+  threshold: number | null;
+};
+
+type ParserModule = {
+  extractFailuresFromReport: (report: unknown) => VisualFailure[];
+  buildVisualRegressionComment: (input: {
+    failures: VisualFailure[];
+    reportUrl: string;
+  }) => string;
+};
+
+const parser = require('../../.github/scripts/parse-visual-regression-results.js') as ParserModule;
+
+test.describe('parse visual regression results', () => {
+  test('should extract failed visual test entries when report has failed tests', () => {
+    const report = {
+      suites: [
+        {
+          title: 'Visual regression',
+          specs: [
+            {
+              title: 'T1: 404 page should match screenshot in SP light mode',
+              tests: [
+                {
+                  projectName: 'sp',
+                  results: [
+                    {
+                      status: 'failed',
+                      errors: [
+                        {
+                          message:
+                            'Error: diffRatio (0.0041) exceeded threshold (0.001) for T1',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          suites: [],
+        },
+      ],
+    };
+
+    const failures = parser.extractFailuresFromReport(report);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      id: 'T1',
+      description: '404 page should match screenshot in SP light mode',
+      project: 'sp',
+      diffRatio: 0.0041,
+      threshold: 0.001,
+    });
+  });
+
+  test('should keep failed test entry even when diff metrics are not in error message', () => {
+    const report = {
+      suites: [
+        {
+          title: 'Visual regression',
+          specs: [
+            {
+              title: 'T2: tags page should match screenshot in PC dark mode',
+              tests: [
+                {
+                  projectName: 'pc',
+                  results: [
+                    {
+                      status: 'failed',
+                      errors: [{ message: 'Timeout of 60000ms exceeded.' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          suites: [],
+        },
+      ],
+    };
+
+    const failures = parser.extractFailuresFromReport(report);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      id: 'T2',
+      description: 'tags page should match screenshot in PC dark mode',
+      diffRatio: null,
+      threshold: null,
+    });
+  });
+
+  test('should return empty failure list when report has no failed tests', () => {
+    const report = {
+      suites: [
+        {
+          title: 'Visual regression',
+          specs: [
+            {
+              title: 'T3: top page should match screenshot in PC light mode',
+              tests: [
+                {
+                  projectName: 'pc',
+                  results: [{ status: 'passed', errors: [] }],
+                },
+              ],
+            },
+          ],
+          suites: [],
+        },
+      ],
+    };
+
+    const failures = parser.extractFailuresFromReport(report);
+
+    expect(failures).toEqual([]);
+  });
+
+  test('should build comment body with identifier, failed table and report URL', () => {
+    const body = parser.buildVisualRegressionComment({
+      failures: [
+        {
+          id: 'T1',
+          description: '404 page should match screenshot in SP light mode',
+          project: 'sp',
+          diffRatio: 0.0041,
+          threshold: 0.001,
+        },
+      ],
+      reportUrl: 'https://example.github.io/repo/pr-123/',
+    });
+
+    expect(body).toMatch(/<!-- visual-regression-report -->/);
+    expect(body).toMatch(
+      /\| T1 \| 404 page should match screenshot in SP light mode \| SP \| 0.41% \| 0.10% \|/,
+    );
+    expect(body).toMatch(
+      /\[View HTML Report\]\(https:\/\/example.github.io\/repo\/pr-123\/\)/,
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,6 +655,13 @@
   resolved "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz"
   integrity sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==
 
+"@types/pngjs@^6.0.5":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@types/pngjs/-/pngjs-6.0.5.tgz#6dec2f7eb8284543ca4e423f3c09b119fa939ea3"
+  integrity sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/react-dom@19.0.4":
   version "19.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.0.4.tgz#bedba97f9346bd4c0fe5d39e689713804ec9ac89"

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@playwright/test@^1.58.2":
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
+  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+  dependencies:
+    playwright "1.58.2"
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -1952,6 +1959,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@~2.3.3:
   version "2.3.3"
@@ -3958,12 +3970,38 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pixelmatch@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-7.1.0.tgz#9d59bddc8c779340e791106c0f245ac33ae4d113"
+  integrity sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==
+  dependencies:
+    pngjs "^7.0.0"
+
 pkg-dir@4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
+
+pngjs@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
+  integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## What is the current behavior?

PR時に本番環境とプレビュー環境のビジュアル差分を自動検出する仕組みがなく、UI変更の確認は手動レビューに依存しています。  
また、差分発生時の根拠画像（比較元・比較先・diff）をCIで体系的に収集するフローも未整備です。

## What is the new behavior?

### 概要（What）

Playwrightを用いたVisual Regressionテスト基盤を追加し、PR時に本番（`https://tminasen.dev`）とVercelプレビュー環境のスクリーンショット差分を自動比較できるようにしました。  
加えて、差分比較ロジックを改善し、画像データ型の扱いを明示して比較の安定性を高めています。

関連: `VISUAL_REGRESSION_TEST_PLAN.md`

### 背景と目的（Why）

`VISUAL_REGRESSION_TEST_PLAN.md` の目的は、主要ページのライト/ダーク・SP/PCのUI崩れをPR段階で検知し、リリース前に回収することです。  
この変更により、レビュー担当者が目視確認だけに頼らず、差分画像を根拠として判断できる状態を作ります。  
特に、Vercelデプロイ完了後のプレビューURLをGitHub Deployment APIから取得して比較することで、実デプロイ環境同士の検証を実現します。

### 変更内容の詳細（How）

### 1) Visual Regressionテスト実装（T1〜T16）
- `tests/visual-regression/pages.spec.ts` に、404/tags/top/article の4ページ × SP/PC × light/dark のケースを実装。
- 本番とプレビューそれぞれのスクリーンショットを撮影し、差分率がしきい値（デフォルト0.1%）以下であることを検証。

### 2) ヘルパー・設定・比較ロジック
- `tests/visual-regression/helpers.ts` に `setColorScheme` / `waitForPageReady` / `takeScreenshot` を実装（T18, T19対応）。
- `tests/visual-regression/config.ts` に `VERCEL_PREVIEW_URL` 取得・URL正規化・ページURL生成を実装（T20対応）。
- `tests/visual-regression/compare.ts` に pixelmatchベースの比較処理、diff画像・JSONレポート出力を実装。
- 追加修正コミットで、比較入力を `Uint8ClampedArray` 化し、PNG書き込みを `Uint8Array` 明示化して型/実行安定性を改善。

### 3) CI統合（T17, T20）
- `.github/workflows/visual-regression.yml` を追加。
- `pull_request`（opened/synchronize/reopened）で実行。
- GitHub Deployment APIをポーリングし、`vercel.app` の成功デプロイURLを解決。
- テスト失敗時に `test-results` と `playwright-report` をartifactとして保存。

### 4) 開発者向け整備
- `playwright.config.ts` を追加（`sp`/`pc` プロジェクト、CI retry設定など）。
- `package.json` に `test:visual` スクリプトと依存関係（`@playwright/test`, `pixelmatch`, `pngjs`, `@types/pngjs`）を追加。
- `.gitignore` と `README.md` を更新し、運用手順と生成物を明記。

### 影響範囲
- CIジョブが追加されるため、PR時の実行時間が増加します。
- 既存アプリケーションロジックへの直接的な破壊的変更はありません。
- 差分画像とレポートの保管運用が可能になります。

## テスト

### 自動テスト
- `tests/visual-regression/pages.spec.ts`（T1〜T16）
- `tests/visual-regression/helpers.spec.ts`（T18, T19）
- `tests/visual-regression/config.spec.ts`（T20）
- `tests/visual-regression/compare.spec.ts`（同一画像/差分画像/サイズ不一致の異常系）

### 計画時テストリストからの差分

| ID | 変更種別 | 内容 | 理由 |
|---|---|---|---|
| T13〜T16 | 入力具体化 | `'/articles/[sample-slug]'` → `'/blog/20200520'` を固定使用 | 実在ページで再現性の高い比較を行うため |
| T20 | 実装詳細化 | Deployment API解決はCI workflow側、`config.spec.ts` は環境変数解決の単体検証に分割 | 責務分離（CI統合ロジックと単体ロジック） |
| （計画外） | 追加 | 画像サイズ不一致時の例外テストを追加 | 比較処理の異常系を明確に担保するため |

### 手動確認が必要な項目
- 意図的にUI差分を発生させたPRで、CI failとartifact保存（T17）が期待通り動くか。
- GitHub Deployment APIのURL解決が、実運用のVercelデプロイパターンで安定するか。

## レビュアーへの依頼事項

- Deployment APIポーリング実装（5分タイムアウト/10秒間隔）の妥当性を確認してください。
- 記事ページの固定サンプル `'/blog/20200520'` が代表ケースとして十分か確認してください。
- 差分しきい値（`0.001` = 0.1%）が現状のレンダリング差異に対して適切か確認してください。
- `VERCEL_PREVIEW_URL` 未設定時に本番同士比較へフォールバックする設計を許容するか確認してください。

## チェックリスト

- [ ] テストがすべてパスしている
- [ ] 型チェックが通っている
- [ ] lint/formatが通っている
- [x] 破壊的変更がない（ある場合は上記で説明済み）
