### PR TITLE
feat: 記事内画像のクリックで拡大表示するLightbox機能を追加

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,7 +1,9 @@
 import type { MDXComponents } from 'mdx/types';
+import { Lightbox } from './src/components/atoms/Lightbox';
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
+    img: (props) => <Lightbox {...props} />,
     a: ({ href, children, ...props }) => {
       const isExternal = href?.startsWith('http');
       return (

--- a/src/components/atoms/Lightbox.tsx
+++ b/src/components/atoms/Lightbox.tsx
@@ -1,0 +1,86 @@
+import { FC, ImgHTMLAttributes, useRef, useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+
+type Props = ImgHTMLAttributes<HTMLImageElement>;
+
+export const Lightbox: FC<Props> = ({ src, alt, ...props }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const handleClose = () => {
+      document.body.style.overflow = '';
+    };
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, [mounted]);
+
+  const openLightbox = useCallback(() => {
+    dialogRef.current?.showModal();
+    document.body.style.overflow = 'hidden';
+  }, []);
+
+  const closeLightbox = useCallback(() => {
+    dialogRef.current?.close();
+    document.body.style.overflow = '';
+  }, []);
+
+  const handleDialogClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) {
+        closeLightbox();
+      }
+    },
+    [closeLightbox],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLImageElement>) => {
+      if (e.key === 'Enter') {
+        openLightbox();
+      }
+    },
+    [openLightbox],
+  );
+
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt ?? ''}
+        {...props}
+        className="cursor-zoom-in"
+        onClick={openLightbox}
+        role="button"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+      />
+      {mounted &&
+        createPortal(
+          <dialog
+            ref={dialogRef}
+            className="lightbox-dialog"
+            onClick={handleDialogClick}
+            aria-label={alt ? `${alt} の拡大表示` : '画像の拡大表示'}
+          >
+            <img src={src} alt={alt ?? ''} className="lightbox-image" />
+            <button
+              className="lightbox-close"
+              onClick={closeLightbox}
+              aria-label="閉じる"
+              type="button"
+            >
+              &times;
+            </button>
+          </dialog>,
+          document.body,
+        )}
+    </>
+  );
+};

--- a/src/styles/article.css
+++ b/src/styles/article.css
@@ -22,6 +22,7 @@
   .prose-article :where(img) {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
+    cursor: zoom-in;
   }
   .prose-article :where(figure) {
     margin-top: 0.5rem;
@@ -35,4 +36,73 @@
     margin-top: 0;
     margin-bottom: 0;
   }
+}
+
+.lightbox-dialog {
+  border: none;
+  background: transparent;
+  padding: 0;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: visible;
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  width: fit-content;
+  height: fit-content;
+}
+
+.lightbox-dialog[open] {
+  animation: lightbox-fade-in 0.2s ease-out;
+}
+
+@keyframes lightbox-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.lightbox-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.7);
+  animation: lightbox-backdrop-fade-in 0.2s ease-out;
+}
+
+@keyframes lightbox-backdrop-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.lightbox-image {
+  max-width: 90vw;
+  max-height: 85vh;
+  object-fit: contain;
+  display: block;
+  border-radius: 0.5rem;
+  border: 2px solid white;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: -2rem;
+  right: -0.5rem;
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: 2rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.25rem;
+}
+
+.lightbox-close:hover {
+  opacity: 0.7;
 }


### PR DESCRIPTION
## What is the current behavior?

記事中の画像は通常サイズで表示されるのみで、クリック/タップしても拡大できず、スクリーンショット等の細かい内容が読み取りにくい。

## What is the new behavior?

記事中の画像をクリック/タップすると Lightbox（拡大表示モーダル）が開き、画像を大きく確認できる。

## 背景と目的

ブログ記事でスクリーンショットを多用しているが、記事幅に収まるサイズで表示されるため細部が読み取りにくいケースがあった。既存の MDX ファイルを一切変更せず、全記事に自動で拡大表示機能を適用することを目的とした。

## 変更内容の詳細

### Lightbox コンポーネントの新規追加（`src/components/atoms/Lightbox.tsx`）

MDX の `img` 要素を置き換えるコンポーネント。クリックで HTML `<dialog>` を `showModal()` で開き、画像を拡大表示する。

- **閉じる操作**: backdrop クリック・閉じるボタン・Escape キー（ネイティブ対応）のすべてに対応
- **背景スクロールのロック**: 開閉時に `document.body.style.overflow` を制御。Escape キーによるネイティブ close にも `close` イベントリスナーで対応
- **`createPortal` の使用**: MDX が `![](...)` を `<p><img/></p>` に変換するため、`<dialog>` を `<p>` 内に配置すると不正な HTML になる。`createPortal` で `document.body` 直下に描画することで回避
- **SSR 対応**: `useState` + `useEffect` でクライアントサイドのみ portal を描画し、静的エクスポート時のハイドレーションエラーを防止
- **アクセシビリティ**: `role="button"`, `tabIndex={0}`, `aria-label` を付与し、キーボード操作にも対応

### MDX コンポーネントのオーバーライド（`mdx-components.tsx`）

既存の `a` タグカスタマイズと同じパターンで `img` を `Lightbox` に差し替え。既存 MDX ファイルの変更は不要で、全記事に自動適用される。

### スタイルの追加（`src/styles/article.css`）

- 記事内 `img` に `cursor: zoom-in` を追加（クリック可能であることを視覚的に示す）
- Lightbox 用スタイル: `<dialog>` の中央固定配置、フェードイン＋スケールアニメーション、半透明黒 backdrop、白枠線・閉じるボタン

## 手動確認が必要な項目

- [x] 画像ありの記事（例: `/blog/wx1t6emdfmmj0ctrokgu`）で画像クリック → 拡大表示されること
- [x] backdrop クリック・Escape・×ボタンで閉じること
- [x] 拡大中に背景がスクロールしないこと
- [x] キーボード（Tab → Enter）で開閉できること
- [x] ライト/ダークモード両方で表示が崩れないこと

## チェックリスト

- [x] `npm run build` で静的エクスポートが成功している
- [x] 既存 MDX ファイルへの変更なし
- [x] 外部ライブラリの追加なし（バンドルサイズへの影響なし）