### PR TITLE
fix: スマートフォン版の表示を改善

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/HeaderComponent.tsx
+++ b/src/components/HeaderComponent.tsx
@@ -22,7 +22,7 @@ export const HeaderComponent: FC<Props> = ({
         </LinkComponent>
       </h1>
       <nav
-        className="absolute left-1 sm:left-7 top-2 z-10"
+        className="absolute flex left-1 sm:left-7 top-1/2 -translate-y-1/2 z-10"
         aria-label="グローバルメニュー"
       >
         <button
@@ -39,7 +39,7 @@ export const HeaderComponent: FC<Props> = ({
           id="global-menu"
           className={`${
             showModal ? 'block' : 'hidden'
-          } mt-2 bg-(--color-bg-card) min-w-[360px] sm:min-w-[500px] min-h-[75vh] rounded-sm`}
+          } absolute top-full mt-2 bg-(--color-bg-card) min-w-[360px] sm:min-w-[500px] min-h-[75vh] rounded-sm`}
         >
           <button
             className="close-button relative border-none bg-transparent w-10 h-10"

--- a/src/styles/article.css
+++ b/src/styles/article.css
@@ -1,19 +1,32 @@
+@layer utilities {
+  .prose-article h1 {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+  }
+  .prose-article h2 {
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+  }
+  .prose-article h3 {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+  @media (min-width: theme('screens.sm')) {
+    .prose-article h1 {
+      font-size: 1.5rem;
+      line-height: 2rem;
+    }
+    .prose-article h2 {
+      font-size: 1.25rem;
+      line-height: 1.75rem;
+    }
+  }
+}
+
 @layer components {
   .prose-article :where(h1, h2, h3, h4, h5, h6) {
     margin-top: 0.75rem;
     margin-bottom: 0.5rem;
-  }
-  .prose-article :where(h1) {
-    font-size: 1.5rem;
-    line-height: 2rem;
-  }
-  .prose-article :where(h2) {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-  }
-  .prose-article :where(h3) {
-    font-size: 1rem;
-    line-height: 1.5rem;
   }
   .prose-article :where(p) {
     margin-top: 0.5rem;

--- a/src/styles/article.css
+++ b/src/styles/article.css
@@ -11,6 +11,15 @@
     font-size: 1rem;
     line-height: 1.5rem;
   }
+  .prose-article h1,
+  .prose-article h2,
+  .prose-article h3,
+  .prose-article h4,
+  .prose-article h5,
+  .prose-article h6 {
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
   @media (min-width: theme('screens.sm')) {
     .prose-article h1 {
       font-size: 1.5rem;
@@ -21,31 +30,25 @@
       line-height: 1.75rem;
     }
   }
-}
-
-@layer components {
-  .prose-article :where(h1, h2, h3, h4, h5, h6) {
-    margin-top: 0.75rem;
-    margin-bottom: 0.5rem;
-  }
-  .prose-article :where(p) {
+  .prose-article p {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
-  .prose-article :where(img) {
+  .prose-article img {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     cursor: zoom-in;
   }
-  .prose-article :where(figure) {
+  .prose-article figure {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
-  .prose-article :where(ul, ol) {
+  .prose-article ul,
+  .prose-article ol {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
-  .prose-article :where(li) {
+  .prose-article li {
     margin-top: 0;
     margin-bottom: 0;
   }


### PR DESCRIPTION
## Summary
- ハンバーガーメニューがヘッダー内で垂直中央に配置されるよう修正（`flex` + `top-1/2 -translate-y-1/2`）
- 記事ページの見出し・本文のfont-sizeとmarginがTailwind Typographyプラグインに上書きされていた問題を修正（`@layer components` → `@layer utilities` に移動し、`:where()` を除去して詳細度を確保）
- モバイル向けに見出しサイズを縮小（h1: 20px, h2: 18px, h3: 16px）、sm以上で元のサイズに復帰

## Test plan
- [ ] モバイル表示（375px幅）でハンバーガーメニューがヘッダー中央に配置されていること
- [ ] モバイル表示でハンバーガーメニューを開閉して正常に動作すること
- [ ] モバイル表示で記事ページの見出し・本文の余白が適切であること
- [ ] デスクトップ表示でレイアウトが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)