### PR TITLE
fix: Lighthouse監査に基づくAccessibility・SEO・パフォーマンス改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 
 # AI
 .clinerules
+/ai-docs

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/CardComponent.tsx
+++ b/src/components/CardComponent.tsx
@@ -10,6 +10,7 @@ type Props = {
   image: ThumbnailImage;
   date: string;
   tags: string[];
+  fetchPriority?: 'high' | 'low' | 'auto';
 };
 
 export const CardComponent: FC<DeepReadonly<Props>> = ({
@@ -19,6 +20,7 @@ export const CardComponent: FC<DeepReadonly<Props>> = ({
   image,
   date,
   tags,
+  fetchPriority,
 }) => {
   const displayTags = tags.slice(0, 3);
 
@@ -31,6 +33,7 @@ export const CardComponent: FC<DeepReadonly<Props>> = ({
           alt={title}
           width={{ pc: image.size.pc.width, sp: image.size.sp.width }}
           height={{ pc: image.size.pc.height, sp: image.size.sp.height }}
+          fetchPriority={fetchPriority}
         />
         <div className="px-2">
           <h2 className="text-2xl font-bold text-center mt-2 max-h-(--card-title-height) leading-(--card-title-line-height) line-clamp-2 overflow-hidden">

--- a/src/components/atoms/ImageComponent.tsx
+++ b/src/components/atoms/ImageComponent.tsx
@@ -12,12 +12,16 @@ interface Props {
     pc: number;
     sp: number;
   };
+  fetchPriority?: 'high' | 'low' | 'auto';
 }
 
 export const Image: FC<Props> = ({
   imageSrc,
   isRounded,
-  alt
+  alt,
+  width,
+  height,
+  fetchPriority,
 }) => {
   return (
     <picture>
@@ -26,6 +30,9 @@ export const Image: FC<Props> = ({
         className={`${isRounded ? 'rounded-t-lg' : ''} w-(--image-sp-width) sm:w-(--image-pc-width) max-h-(--card-image-max-height) object-cover`}
         src={imageSrc}
         alt={alt}
+        width={width.sp}
+        height={height.sp}
+        fetchPriority={fetchPriority}
       />
     </picture>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -27,7 +27,7 @@
         :root {
             /* ダークモード カラー */
             --color-text-base: #e5e7eb;
-            --color-text-muted: #9ca3af;
+            --color-text-muted: #b0b8c4;
             --color-bg-base: #1f2937;
             --color-bg-card: #374151;
             --color-bg-footer: #111827;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,16 +5,19 @@ import { AppProps } from 'next/app';
 import { HeadComponent } from '../components/HeadComponent';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const hasCanonical = Boolean(pageProps.articleMetaData?.path || pageProps.path);
   return (
     <>
-      <HeadComponent
-        title={pageProps.articleMetaData?.title || pageProps.title}
-        ogpImage={pageProps.articleMetaData?.ogpImage}
-        additionalMetaData={undefined}
-        description={undefined}
-        canonicalPath={pageProps.articleMetaData?.path || pageProps.path}
-        ogType={pageProps.ogType}
-      />
+      {hasCanonical && (
+        <HeadComponent
+          title={pageProps.articleMetaData?.title || pageProps.title}
+          ogpImage={pageProps.articleMetaData?.ogpImage}
+          additionalMetaData={undefined}
+          description={undefined}
+          canonicalPath={pageProps.articleMetaData?.path || pageProps.path}
+          ogType={pageProps.ogType}
+        />
+      )}
       <Component {...pageProps} />
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,8 @@ import { CardComponent } from '../components/CardComponent';
 
 const ArticleCardItem: (param: {
   articleData: ArticleMetaData;
-}) => JSX.Element = ({ articleData }) => {
+  fetchPriority?: 'high' | 'low' | 'auto';
+}) => JSX.Element = ({ articleData, fetchPriority }) => {
   return (
     <li>
       <CardComponent
@@ -16,6 +17,7 @@ const ArticleCardItem: (param: {
         excerpt={articleData.description}
         date={articleData.date}
         tags={articleData.tag}
+        fetchPriority={fetchPriority}
       />
     </li>
   );
@@ -27,8 +29,12 @@ const IndexPage: React.FC<{ articleMetaDataList: ArticleMetaData[] }> = ({
   return (
     <PageTemplate>
       <ul className='text-base grid justify-center [grid-template-columns:repeat(auto-fill,var(--card-image-width))] gap-[20px]'>
-        {articleMetaDataList.map(article => (
-          <ArticleCardItem articleData={article} key={article.path} />
+        {articleMetaDataList.map((article, index) => (
+          <ArticleCardItem
+            articleData={article}
+            key={article.path}
+            fetchPriority={index === 0 ? 'high' : undefined}
+          />
         ))}
       </ul>
     </PageTemplate>

--- a/src/styles/highlight/shiki.css
+++ b/src/styles/highlight/shiki.css
@@ -79,4 +79,9 @@ pre span {
     background-color: #374151;
     color: #e5e7eb;
   }
+
+  /* github-dark-dimmed コメント色のコントラスト改善 (3.87:1 → 4.5:1+) */
+  pre span[style*="--shiki-dark:#768390"] {
+    --shiki-dark: #8b949e !important;
+  }
 }


### PR DESCRIPTION
## What is the current behavior?

Lighthouse監査により、以下の問題が検出されている。

**Accessibility（全ページ: 96点）**
- ダークモードのmutedテキスト色（`#9ca3af` on `#374151`）のコントラスト比が4.05:1で、WCAG AA基準の4.5:1を下回る
- コードブロック内のコメント色（github-dark-dimmedテーマ `#768390` on `#22272e`）のコントラスト比が3.87:1

**SEO（記事ページ: 92点）**
- `_app.tsx`と`ArticleLayout.tsx`の両方で`HeadComponent`をレンダリングしており、記事ページに`<link rel="canonical">`が2つ出力される。`_app.tsx`側はMDXページの`pageProps`にpath情報がないため、canonicalPathが`undefined`→`'/'`にフォールバックし、誤って`https://tminasen.dev/`を指す

**パフォーマンス（トップページSP）**
- カードサムネイル画像に`width`/`height`属性がなく、画像ロード時にレイアウトシフトが発生（CLS: 0.09）
- LCP要素（最初のカードサムネイル）に`fetchpriority="high"`が未設定

## What is the new behavior?

全ページでAccessibility: 100、記事ページでSEO: 100を達成し、CLSを0.00に改善。

### canonical URL重複の解消（SEO: 92→100）

`_app.tsx`で`pageProps`にpath情報（`articleMetaData.path`または`path`）が存在する場合のみ`HeadComponent`をレンダリングするよう条件分岐を追加。

MDXの記事ページは`getStaticProps`を持たず`pageProps`が空のため、`_app.tsx`側の`HeadComponent`がスキップされる。記事ページのcanonicalは`ArticleLayout.tsx`が引き続き正しく出力する。トップページやタグページは`getStaticProps`で`path`を返すため、従来どおり`_app.tsx`側で出力される。

### ダークモードのテキストコントラスト改善（Accessibility）

`--color-text-muted`を`#9ca3af`→`#b0b8c4`に変更。`#374151`背景に対するコントラスト比を4.05:1→約4.63:1に引き上げ、WCAG AA基準（4.5:1）をクリア。

### コードブロックコメント色のコントラスト改善（Accessibility）

CSS属性セレクタ `pre span[style*="--shiki-dark:#768390"]` でgithub-dark-dimmedテーマのコメント色を`#768390`→`#8b949e`に上書き。Shikiがインラインスタイルで`--shiki-dark`を設定する仕組みを利用し、テーマファイルを変更せずにコントラスト比を3.87:1→約4.58:1に改善。

### 画像のwidth/height属性追加（CLS: 0.09→0.00）

`ImageComponent`でPropsの`width`/`height`をデストラクチャリングし、`<img>`タグにSP値（`width.sp`/`height.sp`）を属性として渡すよう変更。ブラウザが画像ロード前にアスペクト比を計算できるようになり、レイアウトシフトが解消。

### LCP画像のfetchpriority設定（LCP最適化）

`ImageComponent` → `CardComponent` → `index.tsx`の経路で`fetchPriority`プロパティを伝搬。トップページの最初のカード（`index === 0`）にのみ`fetchPriority="high"`を設定し、LCP要素の優先読み込みを指示。

### その他

- `.gitignore`: Lighthouse監査レポート出力先（`/ai-docs`）を除外に追加
- `next-env.d.ts`: `pnpm build`実行時にNext.jsが自動更新（パスが`.next/types/`→`.next/dev/types/`に変更）

### 改善結果

| ページ | デバイス | Accessibility | SEO | 変化 |
|--------|----------|:------------:|:---:|------|
| トップ | PC/SP | **100** | 100 | A: 96→100 |
| 記事 | PC/SP | **100** | **100** | A: 96→100, SEO: 92→100 |

| パフォーマンス（トップSP） | 改善前 | 改善後 |
|---------------------------|--------|--------|
| CLS | 0.09 | **0.00** |
| LCP | 222ms | **198ms** |

### 手動確認済み項目
- `pnpm build` 成功
- Lighthouse再監査で全ページ Accessibility: 100, SEO: 100 を確認
- パフォーマンストレースでCLS: 0.00を確認
- ダークモードSP表示でmutedテキスト（日付・タグ）の可読性を視覚確認
- ダークモード記事ページでコードブロックコメントの見た目を視覚確認

### レビュアーへの依頼事項

- **canonical条件分岐のアプローチ**: `_app.tsx`側でpagePropsの有無によりHeadComponentの出力を制御している。将来新しいページ種別を追加する場合、`getStaticProps`で`path`を返す必要がある点に注意。この暗黙の契約が許容できるか確認いただきたい
- **コードブロックコメント色の上書き方法**: CSS属性セレクタ`[style*="--shiki-dark:#768390"]`でインラインスタイルの値をマッチさせている。Shikiのテーマ設定が変わった場合にセレクタが一致しなくなるリスクがある。テーマ更新時に再確認が必要
- **mutedテキスト色の変更**: `#b0b8c4`への変更によりライトモードには影響なし（ダークモード専用のCSS変数）。ダークモードでの見た目の印象が許容範囲か確認いただきたい

### チェックリスト

- [x] ビルドが成功している
- [x] 型チェックが通っている（`pnpm build`内で確認）
- [x] 破壊的変更がない
- [x] Lighthouse再監査で改善を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)